### PR TITLE
update gradlew to support JDK 14

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     maven { url 'https://plugins.gradle.org/m2/' }
   }
   dependencies {
-    classpath 'com.netflix.nebula:gradle-ospackage-plugin:6.1.1'
+    classpath 'com.netflix.nebula:gradle-ospackage-plugin:8.3.0'
   }
 }
 

--- a/server/gradle/wrapper/gradle-wrapper.properties
+++ b/server/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updating the gradle wrapper to support running the tutorial with JDK v.14 by

- Updating the classpath property in server/build.gradle to `'com.netflix.nebula:gradle-ospackage-plugin:8.3.0'`

- Updating the distributionUrl property in server/gradle/wrapper/gradle-wrapper.properties to `https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip`